### PR TITLE
#126 | Item Roll Up

### DIFF
--- a/Global.gd
+++ b/Global.gd
@@ -77,6 +77,7 @@ var enemies = null
 var last_combat_enemies = 0
 var floor_level = 1
 var currency = 0
+var roll_up_percentage = 1
 
 # Debugging purposes
 var random

--- a/combat/CombatWin.gd
+++ b/combat/CombatWin.gd
@@ -1,14 +1,30 @@
 extends Node
 
 const Items = preload("res://game/Items.gd")
+const ROLL_UP_STEP = 1
+const DEFAULT_ROLL_UP_PERCENTAGE = 0
 
 onready var loot_list = $CanvasLayer/ColorRect/ColorRect2/ItemList
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var loot_bag = Global.items.generate_combat_loot(Global.floor_level, Global.last_combat_enemies)
+	possible_roll_up(loot_bag)
 	Global.items.apply_loot_bag(loot_bag, Global.player)
 	Global.populate_loot_list(loot_list, loot_bag)
+
+func possible_roll_up(loot_bag):
+	for loot in loot_bag:
+		if loot.type == Items.LootType.GEAR:
+			var rand = Items.get_random_count(Items.LOOT_CHANCE_MAX_RAND)
+			if rand <= Global.roll_up_percentage:
+				var previous_item_name = loot.item.name
+				var new_item = Global.items.roll_up_item(loot.item)
+				loot.item = new_item
+				Global.log(Settings.LogLevel.DEBUG, "[possible_roll_up] Roll Up Item: " + str(previous_item_name) + " | New Item: " + str(new_item.name))
+				Global.roll_up_percentage = DEFAULT_ROLL_UP_PERCENTAGE
+			else:
+				Global.roll_up_percentage += ROLL_UP_STEP
 
 func _on_ok_button_pressed():
 	Global.goto_scene(Global.Scene.OVERWORLD)

--- a/game/Items.gd
+++ b/game/Items.gd
@@ -22,7 +22,7 @@ const LOOT_CHANCE = 80
 const LOOT_CHANCE_MAX_RAND = 100
 const LOOT_PROBABILITY_WEIGHTS = [60, 25, 15]
 # list positions match ItemType enum in Item
-const ITEM_PROBABILITY_WEIGHTS = [94, 3, 2, 1]
+const ITEM_PROBABILITY_WEIGHTS = [75, 15, 5, 5]
 
 const CURRENCY_BASE = 10
 const OXYGEN_BASE = 5
@@ -117,6 +117,16 @@ func get_random_item(tier, item_type, modifier_type=null):
 		item = items[randi() % items.size()]
 	return item
 
+func roll_up_item(roll_item):
+	for item in self._items:
+		if item.tier > roll_item.tier && item.type == roll_item.type:
+			if roll_item.type == Item.ItemType.BONUS || roll_item.type == Item.ItemType.STAT:
+				if item.modifier[Item.GEAR_MODIFIER_TYPE] == roll_item.modifier[Item.GEAR_MODIFIER_TYPE]:
+					return item
+			else:
+				return item
+	return null
+
 static func filter_item_list_by_type(list, type):
 	var filtered_list = []
 	for item in list:
@@ -127,7 +137,7 @@ static func filter_item_list_by_type(list, type):
 static func filter_item_list_by_modifier_type(list, modifier_type):
 	var filtered_list = []
 	for item in list:
-		if item.modifier[Item.ITEM_MODIFIER_TYPE] == modifier_type:
+		if item.modifier[Item.GEAR_MODIFIER_TYPE] == modifier_type:
 			filtered_list.append(item)
 	return filtered_list
 

--- a/project.godot
+++ b/project.godot
@@ -77,6 +77,12 @@ settings={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
  ]
 }
+pause={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":80,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [rendering]
 


### PR DESCRIPTION
* Add the roll up system for gear acquired from combat loot.
* Changed the item probability weights for BONUS, MOVE, ALLY, STAT, from 94, 3, 2, 1 to 75, 15, 5, 5, respectively.