### PR TITLE
#157 | Top Tier Allies

### DIFF
--- a/Global.gd
+++ b/Global.gd
@@ -157,7 +157,7 @@ func _ready():
 		# Advanced Moves
 		Item.new(24, "Space Machete", Item.ItemTier.LEVEL_TWO, Item.ItemType.MOVE, "You swing the space machete.", Moves.MoveList.MELEE_T2),
 		Item.new(25, "Expanded Psychic Fire", Item.ItemTier.LEVEL_TWO, Item.ItemType.MOVE, "More fire solves most problems.", Moves.MoveList.PSY_T2),
-		Item.new(26, "Stim Injections", Item.ItemTier.LEVEL_ONE, Item.ItemType.MOVE, "The injections make you feel invincible!", Moves.MoveList.HEAL_T2),
+		Item.new(26, "Stim Injections", Item.ItemTier.LEVEL_TWO, Item.ItemType.MOVE, "The injections make you feel invincible!", Moves.MoveList.HEAL_T2),
 
 		# T3 Bonus Items
 		Item.new(27, "Plasma Sabre", Item.ItemTier.LEVEL_THREE, Item.ItemType.BONUS, "It cuts ALL THE THINGS!", [Creature.Stats.ATTACK, 8]),

--- a/combat/Combat.gd
+++ b/combat/Combat.gd
@@ -104,6 +104,8 @@ var _menu_target = null
 var _menu_creature = null
 var _creature_moves = null
 var _hover = 0
+var _hover_move_last_position = 0
+var _hover_target_last_position = 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -151,6 +153,8 @@ func _ready():
 		# Setup Scene
 		var creature_scene = EnemyScene.instance()
 		creature_scene.set("position", position)
+		if typeof(ally.get_tier()) == TYPE_INT:
+			creature_scene.set_flip_h(true)
 		creature_scene.creature_name = ally.get_name()
 		creature_scene.show_name = true
 		creature_scene.creature_size = ally.size
@@ -195,14 +199,14 @@ func _process(delta):
 			if creature.get_ticks() >= ACTION_AVAILABLE_TICKS && !creature.is_queued:
 				if creature.get_behavior() == Creature.Behavior.PLAYER:
 					show_move_options(creature)
-				    creature.is_queued = true
+					creature.is_queued = true
 				else:
 					var move_id = creature.get_move()
 					var move = Global.moves.get_move_by_id(move_id)
 					var target = creature.choose_target(move, enemies)
 					if target:
-					    action_queue.append(CombatEvent.new(move, creature, target))
-				        creature.is_queued = true
+						action_queue.append(CombatEvent.new(move, creature, target))
+						creature.is_queued = true
 			else:
 				creature.add_ticks(delta)
 		creature.update_health_percentage()
@@ -263,7 +267,8 @@ func _input(event):
 				_menu_move = move
 				_phase = MenuPhase.TARGET_SELECT
 				MoveSelectionArrow.visible = false
-				_hover = FIRST_POSITION
+				_hover_move_last_position = _hover
+				_hover = _hover_target_last_position
 				update_selection_arrow(_hover)
 				TargetSelectionArrow.visible = true
 			elif _phase == MenuPhase.TARGET_SELECT:
@@ -329,7 +334,8 @@ func reset_menuing():
 	_menu_creature = null
 	_menu_move = null
 	_phase = MenuPhase.NONE
-	_hover = 0
+	_hover_target_last_position = _hover
+	_hover = _hover_move_last_position
 	CombatInstructions.visible = false
 	TargetSelectionArrow.visible = false
 	MoveSelectionArrow.visible = false

--- a/game/GlobalPlayer.gd
+++ b/game/GlobalPlayer.gd
@@ -2,6 +2,8 @@ extends "res://game/Creature.gd"
 
 const Item = preload("res://game/Item.gd")
 
+const MAX_ALLIES = 2
+
 var _tier = null
 var _items = null
 var _max_oxygen = null
@@ -105,10 +107,10 @@ func get_moves():
 				var found_previous_tier = false
 				# Loop through the tiers
 				for previous_tier in move.previous_tiers:
-				    # see if this tier exists in the moves list
+					# see if this tier exists in the moves list
 					var position = moves.find(previous_tier)
 					if position > -1:
-					    # replace the existing lower tier move with this higher tier move
+						# replace the existing lower tier move with this higher tier move
 						moves[position] = item.modifier
 						found_previous_tier = true
 						continue
@@ -124,4 +126,7 @@ func get_allies():
 		var item = Global.items.get_item_by_id(item_id)
 		if item.type == Item.ItemType.ALLY:
 				allies.append(item.modifier)
+	allies.sort()
+	while allies.size() > MAX_ALLIES:
+		allies.pop_front()
 	return allies


### PR DESCRIPTION
* Only the 2 best allies are added to the player's combat group.
* The position of the hover arrow during move selection and target selection in combat screen is remembered.
* Allies now face correct direction during fight.
* Moved Stim Injections to tier two items.