### PR TITLE
Release Crashes

### DIFF
--- a/Global.gd
+++ b/Global.gd
@@ -57,7 +57,7 @@ const STAT_STEP = 1
 const OXYGEN_STEP = 80
 const HEALTH_STEP = 25
 
-const version = "1.0.0"
+const version = "1.0.1"
 
 var debug = LogLevel.ERROR
 var game_loaded = false
@@ -127,7 +127,7 @@ func _ready():
 	else:
 		random.randomize()
 	current_seed = random.get_seed()
-	self.log(Global.LogLevel.DEBUG, "[Global] Random Seed: " + str(current_seed) + " | DEBUG Seed: " + str(seed_value))
+	self.log(Global.LogLevel.ERROR, "[Global] Random Seed: " + str(current_seed) + " | DEBUG Seed: " + str(seed_value))
 
 	var root = get_tree().get_root()
 	current_scene = root.get_child(root.get_child_count() - 1)
@@ -343,6 +343,11 @@ func reset_global_data():
 	}
 	currency = 0
 	build_player()
+
+func drop_scene(scene):
+	if scene == Global.Scene.OVERWORLD && persisted_scenes[scene] != null:
+		persisted_scenes[scene].queue_free()
+		persisted_scenes[scene] = null
 
 func goto_scene(target_scene, function_call = null):
 	# This function will usually be called from a signal callback,

--- a/Story.gd
+++ b/Story.gd
@@ -6,4 +6,5 @@ func _ready():
 func _on_StartGame_pressed():
 	Global.reset_global_data()
 	Global.build_player()
+	Global.drop_scene(Global.Scene.OVERWORLD)
 	Global.goto_scene(Global.Scene.OVERWORLD, "restart_overworld")

--- a/ground_control/GroundControl.gd
+++ b/ground_control/GroundControl.gd
@@ -522,5 +522,6 @@ func _on_StartGameMission_pressed():
 	#Goes back to game
 	Global.build_player()
 	audio.stop()
+	Global.drop_scene(Global.Scene.OVERWORLD)
 	Global.goto_scene(Global.Scene.OVERWORLD, "restart_overworld")
 	


### PR DESCRIPTION
* Reinitializing Overworld every run start seems to prevent the crashes from happening.
* Log Seed every run for players.
* Increment version.

I believe this is preventing the issues from occurring in many issues.

Closes #242 
Closes #241 
Closes #243 